### PR TITLE
Add Combine-based app flow

### DIFF
--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		17E008AE888F95484D12CC88 /* Pods_iOS_TemplateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3ECC42EE33D926912F99EDE /* Pods_iOS_TemplateTests.framework */; };
+		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
+		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
+		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
+		18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */; };
 		4FB2AC4C4B63B3514455C1E0 /* Pods_iOS_Template_iOS_TemplateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39579F71529DADEC459444 /* Pods_iOS_Template_iOS_TemplateUITests.framework */; };
 		6120229526283D0200A5A725 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229326283D0100A5A725 /* .swiftlint.yml */; };
 		6120229626283D0200A5A725 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229426283D0100A5A725 /* swiftgen.yml */; };
@@ -62,6 +66,10 @@
 /* Begin PBXFileReference section */
 		0E0076B30315E9FB7514F430 /* Pods_iOS_Template.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Template.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		10AED7286AD29028EC476125 /* Pods-iOS-TemplateTests.qa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.qa.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.qa.xcconfig"; sourceTree = "<group>"; };
+		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
+		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
+		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
+		18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindowCoordinator.swift; sourceTree = "<group>"; };
 		2EB2D38274FF78CC82BEC667 /* Pods-iOS-Template.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Template.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-Template/Pods-iOS-Template.devrelease.xcconfig"; sourceTree = "<group>"; };
 		58CB12D784EBF75EEE0E84CB /* Pods-iOS-TemplateTests.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.devrelease.xcconfig"; sourceTree = "<group>"; };
 		5AB5AFD6E3298AF76607D7A2 /* Pods-iOS-TemplateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.release.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -166,6 +174,17 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		18C70E51265FAD5500EF8F77 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */,
+				18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */,
+				18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */,
+				18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */,
+			);
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
 		612022AB26283F0A00A5A725 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -210,6 +229,7 @@
 			children = (
 				61C63D75262839CC007EA247 /* Start */,
 				61C63DB926283B39007EA247 /* Modules */,
+				18C70E51265FAD5500EF8F77 /* Coordinators */,
 				61C63DA126283AD1007EA247 /* Networking */,
 				61C63D8E26283A87007EA247 /* Helpers */,
 				61C63D3426283916007EA247 /* Assets.xcassets */,
@@ -595,6 +615,7 @@
 			files = (
 				61C63DCE26283B9B007EA247 /* HomeViewCoordinator.swift in Sources */,
 				61C63D9826283AB5007EA247 /* Callback.swift in Sources */,
+				18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */,
 				61C63DB026283B0D007EA247 /* Networking.swift in Sources */,
 				61C63D8226283A0D007EA247 /* Coordinator.swift in Sources */,
 				61C63DD026283B9B007EA247 /* GithubModel.swift in Sources */,
@@ -607,10 +628,13 @@
 				61C63DD926283BA4007EA247 /* RepoListCoordinator.swift in Sources */,
 				61C63DA326283AED007EA247 /* Endpoints.swift in Sources */,
 				61C63DB526283B24007EA247 /* NetworkingError.swift in Sources */,
+				18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */,
 				61C63DCF26283B9B007EA247 /* HomeViewController.swift in Sources */,
 				61C63DDC26283BA4007EA247 /* RepoModel.swift in Sources */,
+				18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */,
 				61C63DD126283B9B007EA247 /* HomeViewModel.swift in Sources */,
 				61C63DDB26283BA4007EA247 /* RepoListViewController.swift in Sources */,
+				18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */,
 				61C63D9D26283AC5007EA247 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -714,7 +738,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -731,8 +755,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-Template/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -751,9 +776,9 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -773,7 +798,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -839,7 +864,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -856,8 +881,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-Template/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -876,9 +902,9 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -898,7 +924,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -964,7 +990,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1019,7 +1045,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1036,8 +1062,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-Template/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1056,8 +1083,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-Template/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1076,9 +1104,9 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1099,9 +1127,9 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1121,7 +1149,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1142,7 +1170,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 499NLNJYQN;
+				DEVELOPMENT_TEAM = 7JTC3SZUZB;
 				INFOPLIST_FILE = "iOS-TemplateUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0817266126E5005FD4EE /* UserSelectionHandling.swift */; };
 		182E0823266128E7005FD4EE /* ReposListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0822266128E7005FD4EE /* ReposListViewController.swift */; };
 		182E082B26613400005FD4EE /* RepositoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E082A26613400005FD4EE /* RepositoriesDataSource.swift */; };
+		182F8DAF266605D000247F4E /* NetworkingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */; };
 		182F8DB426660DF500247F4E /* MockNetworkingPublisherProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
@@ -79,6 +80,7 @@
 		182E0817266126E5005FD4EE /* UserSelectionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectionHandling.swift; sourceTree = "<group>"; };
 		182E0822266128E7005FD4EE /* ReposListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReposListViewController.swift; sourceTree = "<group>"; };
 		182E082A26613400005FD4EE /* RepositoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesDataSource.swift; sourceTree = "<group>"; };
+		182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingControllerTests.swift; sourceTree = "<group>"; };
 		182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingPublisherProvider.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				612022C226283FB300A5A725 /* NetworkingMockTests.swift */,
 				612022C726283FE300A5A725 /* GithubEndpoints.swift */,
 				61C63D4426283916007EA247 /* Info.plist */,
+				182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */,
 				182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */,
 			);
 			path = "iOS-TemplateTests";
@@ -699,6 +702,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				612022B626283F5000A5A725 /* Environment.swift in Sources */,
+				182F8DAF266605D000247F4E /* NetworkingControllerTests.swift in Sources */,
 				612022A726283EFE00A5A725 /* HomeViewModelTests.swift in Sources */,
 				182F8DB426660DF500247F4E /* MockNetworkingPublisherProvider.swift in Sources */,
 				612022C326283FB300A5A725 /* NetworkingMockTests.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		17E008AE888F95484D12CC88 /* Pods_iOS_TemplateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3ECC42EE33D926912F99EDE /* Pods_iOS_TemplateTests.framework */; };
 		182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0817266126E5005FD4EE /* UserSelectionHandling.swift */; };
 		182E0823266128E7005FD4EE /* ReposListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0822266128E7005FD4EE /* ReposListViewController.swift */; };
+		182E082B26613400005FD4EE /* RepositoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E082A26613400005FD4EE /* RepositoriesDataSource.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
@@ -76,6 +77,7 @@
 		10AED7286AD29028EC476125 /* Pods-iOS-TemplateTests.qa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.qa.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.qa.xcconfig"; sourceTree = "<group>"; };
 		182E0817266126E5005FD4EE /* UserSelectionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectionHandling.swift; sourceTree = "<group>"; };
 		182E0822266128E7005FD4EE /* ReposListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReposListViewController.swift; sourceTree = "<group>"; };
+		182E082A26613400005FD4EE /* RepositoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesDataSource.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				182E0822266128E7005FD4EE /* ReposListViewController.swift */,
+				182E082A26613400005FD4EE /* RepositoriesDataSource.swift */,
 			);
 			path = ReposList;
 			sourceTree = "<group>";
@@ -663,6 +666,7 @@
 				61C63DD026283B9B007EA247 /* GithubModel.swift in Sources */,
 				61C63DAB26283AFF007EA247 /* GithubEndpoints.swift in Sources */,
 				61C63D2C26283913007EA247 /* AppDelegate.swift in Sources */,
+				182E082B26613400005FD4EE /* RepositoriesDataSource.swift in Sources */,
 				61C63D9026283AA3007EA247 /* UITableView+Extensions.swift in Sources */,
 				61C63D2E26283913007EA247 /* SceneDelegate.swift in Sources */,
 				61C63DDA26283BA4007EA247 /* RepoListViewModel.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0817266126E5005FD4EE /* UserSelectionHandling.swift */; };
 		182E0823266128E7005FD4EE /* ReposListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0822266128E7005FD4EE /* ReposListViewController.swift */; };
 		182E082B26613400005FD4EE /* RepositoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E082A26613400005FD4EE /* RepositoriesDataSource.swift */; };
+		182F8DB426660DF500247F4E /* MockNetworkingPublisherProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
@@ -78,6 +79,7 @@
 		182E0817266126E5005FD4EE /* UserSelectionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectionHandling.swift; sourceTree = "<group>"; };
 		182E0822266128E7005FD4EE /* ReposListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReposListViewController.swift; sourceTree = "<group>"; };
 		182E082A26613400005FD4EE /* RepositoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesDataSource.swift; sourceTree = "<group>"; };
+		182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingPublisherProvider.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				612022C226283FB300A5A725 /* NetworkingMockTests.swift */,
 				612022C726283FE300A5A725 /* GithubEndpoints.swift */,
 				61C63D4426283916007EA247 /* Info.plist */,
+				182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */,
 			);
 			path = "iOS-TemplateTests";
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 			files = (
 				612022B626283F5000A5A725 /* Environment.swift in Sources */,
 				612022A726283EFE00A5A725 /* HomeViewModelTests.swift in Sources */,
+				182F8DB426660DF500247F4E /* MockNetworkingPublisherProvider.swift in Sources */,
 				612022C326283FB300A5A725 /* NetworkingMockTests.swift in Sources */,
 				612022C826283FE300A5A725 /* GithubEndpoints.swift in Sources */,
 				612022AE26283F2F00A5A725 /* NetworkingMock.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */; };
 		18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */; };
 		18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */; };
+		18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */; };
 		4FB2AC4C4B63B3514455C1E0 /* Pods_iOS_Template_iOS_TemplateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39579F71529DADEC459444 /* Pods_iOS_Template_iOS_TemplateUITests.framework */; };
 		6120229526283D0200A5A725 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229326283D0100A5A725 /* .swiftlint.yml */; };
 		6120229626283D0200A5A725 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229426283D0100A5A725 /* swiftgen.yml */; };
@@ -74,6 +75,7 @@
 		18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindowCoordinator.swift; sourceTree = "<group>"; };
 		18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewController.swift; sourceTree = "<group>"; };
 		18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersDataSource.swift; sourceTree = "<group>"; };
+		18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExtensions.swift; sourceTree = "<group>"; };
 		2EB2D38274FF78CC82BEC667 /* Pods-iOS-Template.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Template.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-Template/Pods-iOS-Template.devrelease.xcconfig"; sourceTree = "<group>"; };
 		58CB12D784EBF75EEE0E84CB /* Pods-iOS-TemplateTests.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.devrelease.xcconfig"; sourceTree = "<group>"; };
 		5AB5AFD6E3298AF76607D7A2 /* Pods-iOS-TemplateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.release.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 		61C63DA126283AD1007EA247 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */,
 				61C63DA226283AED007EA247 /* Endpoints.swift */,
 				61C63DAA26283AFF007EA247 /* GithubEndpoints.swift */,
 				61C63DAF26283B0D007EA247 /* Networking.swift */,
@@ -638,6 +641,7 @@
 				61C63D9026283AA3007EA247 /* UITableView+Extensions.swift in Sources */,
 				61C63D2E26283913007EA247 /* SceneDelegate.swift in Sources */,
 				61C63DDA26283BA4007EA247 /* RepoListViewModel.swift in Sources */,
+				18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */,
 				61C63D8726283A2A007EA247 /* Environment.swift in Sources */,
 				61C63DD926283BA4007EA247 /* RepoListCoordinator.swift in Sources */,
 				61C63DA326283AED007EA247 /* Endpoints.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		17E008AE888F95484D12CC88 /* Pods_iOS_TemplateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3ECC42EE33D926912F99EDE /* Pods_iOS_TemplateTests.framework */; };
 		182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0817266126E5005FD4EE /* UserSelectionHandling.swift */; };
+		182E0823266128E7005FD4EE /* ReposListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0822266128E7005FD4EE /* ReposListViewController.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
@@ -74,6 +75,7 @@
 		0E0076B30315E9FB7514F430 /* Pods_iOS_Template.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Template.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		10AED7286AD29028EC476125 /* Pods-iOS-TemplateTests.qa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.qa.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.qa.xcconfig"; sourceTree = "<group>"; };
 		182E0817266126E5005FD4EE /* UserSelectionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectionHandling.swift; sourceTree = "<group>"; };
+		182E0822266128E7005FD4EE /* ReposListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReposListViewController.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -186,6 +188,14 @@
 				10AED7286AD29028EC476125 /* Pods-iOS-TemplateTests.qa.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		182E0821266128AE005FD4EE /* ReposList */ = {
+			isa = PBXGroup;
+			children = (
+				182E0822266128E7005FD4EE /* ReposListViewController.swift */,
+			);
+			path = ReposList;
 			sourceTree = "<group>";
 		};
 		18C70E51265FAD5500EF8F77 /* Coordinators */ = {
@@ -328,6 +338,7 @@
 			children = (
 				61C63DC226283B53007EA247 /* Home */,
 				61C63DC326283B58007EA247 /* RepoList */,
+				182E0821266128AE005FD4EE /* ReposList */,
 				18C70E83265FCB1E00EF8F77 /* UsersList */,
 			);
 			path = Modules;
@@ -657,6 +668,7 @@
 				61C63DDA26283BA4007EA247 /* RepoListViewModel.swift in Sources */,
 				18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */,
 				61C63D8726283A2A007EA247 /* Environment.swift in Sources */,
+				182E0823266128E7005FD4EE /* ReposListViewController.swift in Sources */,
 				61C63DD926283BA4007EA247 /* RepoListCoordinator.swift in Sources */,
 				18C70E892660CF7500EF8F77 /* NetworkingController.swift in Sources */,
 				61C63DA326283AED007EA247 /* Endpoints.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */; };
 		18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */; };
 		18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */; };
+		18C70E942660E72000EF8F77 /* NetworkingPublisherProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */; };
 		18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */; };
 		18C70EA72660F19900EF8F77 /* URLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA62660F19900EF8F77 /* URLProvider.swift */; };
 		4FB2AC4C4B63B3514455C1E0 /* Pods_iOS_Template_iOS_TemplateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39579F71529DADEC459444 /* Pods_iOS_Template_iOS_TemplateUITests.framework */; };
@@ -76,6 +77,7 @@
 		18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindowCoordinator.swift; sourceTree = "<group>"; };
 		18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewController.swift; sourceTree = "<group>"; };
 		18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersDataSource.swift; sourceTree = "<group>"; };
+		18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingPublisherProviding.swift; sourceTree = "<group>"; };
 		18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExtensions.swift; sourceTree = "<group>"; };
 		18C70EA62660F19900EF8F77 /* URLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProvider.swift; sourceTree = "<group>"; };
 		2EB2D38274FF78CC82BEC667 /* Pods-iOS-Template.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Template.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-Template/Pods-iOS-Template.devrelease.xcconfig"; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 		61C63DA126283AD1007EA247 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */,
 				18C70EA62660F19900EF8F77 /* URLProvider.swift */,
 				18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */,
 				61C63DA226283AED007EA247 /* Endpoints.swift */,
@@ -650,6 +653,7 @@
 				61C63DD926283BA4007EA247 /* RepoListCoordinator.swift in Sources */,
 				61C63DA326283AED007EA247 /* Endpoints.swift in Sources */,
 				61C63DB526283B24007EA247 /* NetworkingError.swift in Sources */,
+				18C70E942660E72000EF8F77 /* NetworkingPublisherProviding.swift in Sources */,
 				18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */,
 				61C63DCF26283B9B007EA247 /* HomeViewController.swift in Sources */,
 				18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		17E008AE888F95484D12CC88 /* Pods_iOS_TemplateTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3ECC42EE33D926912F99EDE /* Pods_iOS_TemplateTests.framework */; };
+		182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E0817266126E5005FD4EE /* UserSelectionHandling.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
@@ -72,6 +73,7 @@
 /* Begin PBXFileReference section */
 		0E0076B30315E9FB7514F430 /* Pods_iOS_Template.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Template.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		10AED7286AD29028EC476125 /* Pods-iOS-TemplateTests.qa.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.qa.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.qa.xcconfig"; sourceTree = "<group>"; };
+		182E0817266126E5005FD4EE /* UserSelectionHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectionHandling.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 				18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */,
 				18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */,
 				18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */,
+				182E0817266126E5005FD4EE /* UserSelectionHandling.swift */,
 				18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */,
 			);
 			path = Coordinators;
@@ -639,6 +642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				182E0818266126E5005FD4EE /* UserSelectionHandling.swift in Sources */,
 				61C63DCE26283B9B007EA247 /* HomeViewCoordinator.swift in Sources */,
 				61C63D9826283AB5007EA247 /* Callback.swift in Sources */,
 				18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */; };
 		18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */; };
 		18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */; };
+		18C70EA72660F19900EF8F77 /* URLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA62660F19900EF8F77 /* URLProvider.swift */; };
 		4FB2AC4C4B63B3514455C1E0 /* Pods_iOS_Template_iOS_TemplateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39579F71529DADEC459444 /* Pods_iOS_Template_iOS_TemplateUITests.framework */; };
 		6120229526283D0200A5A725 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229326283D0100A5A725 /* .swiftlint.yml */; };
 		6120229626283D0200A5A725 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229426283D0100A5A725 /* swiftgen.yml */; };
@@ -76,6 +77,7 @@
 		18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewController.swift; sourceTree = "<group>"; };
 		18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersDataSource.swift; sourceTree = "<group>"; };
 		18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExtensions.swift; sourceTree = "<group>"; };
+		18C70EA62660F19900EF8F77 /* URLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProvider.swift; sourceTree = "<group>"; };
 		2EB2D38274FF78CC82BEC667 /* Pods-iOS-Template.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Template.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-Template/Pods-iOS-Template.devrelease.xcconfig"; sourceTree = "<group>"; };
 		58CB12D784EBF75EEE0E84CB /* Pods-iOS-TemplateTests.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.devrelease.xcconfig"; sourceTree = "<group>"; };
 		5AB5AFD6E3298AF76607D7A2 /* Pods-iOS-TemplateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.release.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 		61C63DA126283AD1007EA247 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				18C70EA62660F19900EF8F77 /* URLProvider.swift */,
 				18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */,
 				61C63DA226283AED007EA247 /* Endpoints.swift */,
 				61C63DAA26283AFF007EA247 /* GithubEndpoints.swift */,
@@ -633,6 +636,7 @@
 				61C63DCE26283B9B007EA247 /* HomeViewCoordinator.swift in Sources */,
 				61C63D9826283AB5007EA247 /* Callback.swift in Sources */,
 				18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */,
+				18C70EA72660F19900EF8F77 /* URLProvider.swift in Sources */,
 				61C63DB026283B0D007EA247 /* Networking.swift in Sources */,
 				61C63D8226283A0D007EA247 /* Coordinator.swift in Sources */,
 				61C63DD026283B9B007EA247 /* GithubModel.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
 		18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */; };
+		18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */; };
+		18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */; };
 		4FB2AC4C4B63B3514455C1E0 /* Pods_iOS_Template_iOS_TemplateUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA39579F71529DADEC459444 /* Pods_iOS_Template_iOS_TemplateUITests.framework */; };
 		6120229526283D0200A5A725 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229326283D0100A5A725 /* .swiftlint.yml */; };
 		6120229626283D0200A5A725 /* swiftgen.yml in Resources */ = {isa = PBXBuildFile; fileRef = 6120229426283D0100A5A725 /* swiftgen.yml */; };
@@ -70,6 +72,8 @@
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
 		18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindowCoordinator.swift; sourceTree = "<group>"; };
+		18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewController.swift; sourceTree = "<group>"; };
+		18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersDataSource.swift; sourceTree = "<group>"; };
 		2EB2D38274FF78CC82BEC667 /* Pods-iOS-Template.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-Template.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-Template/Pods-iOS-Template.devrelease.xcconfig"; sourceTree = "<group>"; };
 		58CB12D784EBF75EEE0E84CB /* Pods-iOS-TemplateTests.devrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.devrelease.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.devrelease.xcconfig"; sourceTree = "<group>"; };
 		5AB5AFD6E3298AF76607D7A2 /* Pods-iOS-TemplateTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS-TemplateTests.release.xcconfig"; path = "Target Support Files/Pods-iOS-TemplateTests/Pods-iOS-TemplateTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -183,6 +187,15 @@
 				18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */,
 			);
 			path = Coordinators;
+			sourceTree = "<group>";
+		};
+		18C70E83265FCB1E00EF8F77 /* UsersList */ = {
+			isa = PBXGroup;
+			children = (
+				18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */,
+				18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */,
+			);
+			path = UsersList;
 			sourceTree = "<group>";
 		};
 		612022AB26283F0A00A5A725 /* Extensions */ = {
@@ -300,6 +313,7 @@
 			children = (
 				61C63DC226283B53007EA247 /* Home */,
 				61C63DC326283B58007EA247 /* RepoList */,
+				18C70E83265FCB1E00EF8F77 /* UsersList */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -630,9 +644,11 @@
 				61C63DB526283B24007EA247 /* NetworkingError.swift in Sources */,
 				18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */,
 				61C63DCF26283B9B007EA247 /* HomeViewController.swift in Sources */,
+				18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */,
 				61C63DDC26283BA4007EA247 /* RepoModel.swift in Sources */,
 				18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */,
 				61C63DD126283B9B007EA247 /* HomeViewModel.swift in Sources */,
+				18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */,
 				61C63DDB26283BA4007EA247 /* RepoListViewController.swift in Sources */,
 				18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */,
 				61C63D9D26283AC5007EA247 /* Constants.swift in Sources */,

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		182E082B26613400005FD4EE /* RepositoriesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182E082A26613400005FD4EE /* RepositoriesDataSource.swift */; };
 		182F8DAF266605D000247F4E /* NetworkingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */; };
 		182F8DB426660DF500247F4E /* MockNetworkingPublisherProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */; };
+		182F8DB9266633C700247F4E /* URLProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F8DB8266633C700247F4E /* URLProviderTests.swift */; };
 		18C70E38265FACF500EF8F77 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */; };
 		18C70E43265FAD0600EF8F77 /* RootNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */; };
 		18C70E48265FAD2A00EF8F77 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */; };
@@ -82,6 +83,7 @@
 		182E082A26613400005FD4EE /* RepositoriesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesDataSource.swift; sourceTree = "<group>"; };
 		182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingControllerTests.swift; sourceTree = "<group>"; };
 		182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingPublisherProvider.swift; sourceTree = "<group>"; };
+		182F8DB8266633C700247F4E /* URLProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProviderTests.swift; sourceTree = "<group>"; };
 		18C70E37265FACF500EF8F77 /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E42265FAD0600EF8F77 /* RootNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationCoordinator.swift; sourceTree = "<group>"; };
 		18C70E47265FAD2A00EF8F77 /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				61C63D4426283916007EA247 /* Info.plist */,
 				182F8DAE266605D000247F4E /* NetworkingControllerTests.swift */,
 				182F8DB326660DF500247F4E /* MockNetworkingPublisherProvider.swift */,
+				182F8DB8266633C700247F4E /* URLProviderTests.swift */,
 			);
 			path = "iOS-TemplateTests";
 			sourceTree = "<group>";
@@ -708,6 +711,7 @@
 				612022C326283FB300A5A725 /* NetworkingMockTests.swift in Sources */,
 				612022C826283FE300A5A725 /* GithubEndpoints.swift in Sources */,
 				612022AE26283F2F00A5A725 /* NetworkingMock.swift in Sources */,
+				182F8DB9266633C700247F4E /* URLProviderTests.swift in Sources */,
 				612022BB26283F7D00A5A725 /* RepoListViewModelTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS-Template.xcodeproj/project.pbxproj
+++ b/iOS-Template.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18C70E4D265FAD3D00EF8F77 /* RootWindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */; };
 		18C70E59265FB0E400EF8F77 /* UsersListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */; };
 		18C70E7C265FC9C500EF8F77 /* GitHubUsersDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */; };
+		18C70E892660CF7500EF8F77 /* NetworkingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E882660CF7400EF8F77 /* NetworkingController.swift */; };
 		18C70E942660E72000EF8F77 /* NetworkingPublisherProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */; };
 		18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */; };
 		18C70EA72660F19900EF8F77 /* URLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C70EA62660F19900EF8F77 /* URLProvider.swift */; };
@@ -77,6 +78,7 @@
 		18C70E4C265FAD3D00EF8F77 /* RootWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindowCoordinator.swift; sourceTree = "<group>"; };
 		18C70E58265FB0E400EF8F77 /* UsersListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersListViewController.swift; sourceTree = "<group>"; };
 		18C70E7B265FC9C500EF8F77 /* GitHubUsersDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubUsersDataSource.swift; sourceTree = "<group>"; };
+		18C70E882660CF7400EF8F77 /* NetworkingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingController.swift; sourceTree = "<group>"; };
 		18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingPublisherProviding.swift; sourceTree = "<group>"; };
 		18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExtensions.swift; sourceTree = "<group>"; };
 		18C70EA62660F19900EF8F77 /* URLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProvider.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 			isa = PBXGroup;
 			children = (
 				18C70E932660E72000EF8F77 /* NetworkingPublisherProviding.swift */,
+				18C70E882660CF7400EF8F77 /* NetworkingController.swift */,
 				18C70EA62660F19900EF8F77 /* URLProvider.swift */,
 				18C70EA12660EA4500EF8F77 /* CombineExtensions.swift */,
 				61C63DA226283AED007EA247 /* Endpoints.swift */,
@@ -651,6 +654,7 @@
 				18C70EA22660EA4500EF8F77 /* CombineExtensions.swift in Sources */,
 				61C63D8726283A2A007EA247 /* Environment.swift in Sources */,
 				61C63DD926283BA4007EA247 /* RepoListCoordinator.swift in Sources */,
+				18C70E892660CF7500EF8F77 /* NetworkingController.swift in Sources */,
 				61C63DA326283AED007EA247 /* Endpoints.swift in Sources */,
 				61C63DB526283B24007EA247 /* NetworkingError.swift in Sources */,
 				18C70E942660E72000EF8F77 /* NetworkingPublisherProviding.swift in Sources */,

--- a/iOS-Template/Coordinators/NavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/NavigationCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  NavigationCoordinator.swift
+//  Pods
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+protocol NavigationCoordinator: Coordinator {
+  
+  var controller: UINavigationController { get }
+  
+  var childCoordinators: [Coordinator] { get }
+  
+}

--- a/iOS-Template/Coordinators/RootNavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/RootNavigationCoordinator.swift
@@ -19,7 +19,7 @@ final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
   }
   
   private func makeRootViewController() -> UIViewController {
-    return UsersListViewController()
+    return UsersListViewController(userSelectionHandler: self)
   }
   
   func start() {
@@ -31,7 +31,7 @@ final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
 extension RootNavigationCoordinator: UserSelectionHandling {
   
   func didSelect(user: GithubUser) {
-    dump(user)
+    controller.pushViewController(UIViewController(), animated: true)
   }
   
 }

--- a/iOS-Template/Coordinators/RootNavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/RootNavigationCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  RootNavigationCoordinator.swift
+//  iOS-Template
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
+  
+  private(set) var controller: UINavigationController
+  private(set) var childCoordinators: [Coordinator] = []
+  private let environment: Environment
+  
+  init(navigationController: UINavigationController = .init(), environment: Environment) {
+    self.controller = navigationController
+    self.environment = environment
+  }
+  
+  private func makeRootViewController() -> UIViewController {
+    let viewController = UIViewController()
+    viewController.view.backgroundColor = .systemGreen
+    return viewController
+  }
+  
+  func start() {
+    controller.pushViewController(makeRootViewController(), animated: false)
+  }
+  
+}

--- a/iOS-Template/Coordinators/RootNavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/RootNavigationCoordinator.swift
@@ -27,3 +27,11 @@ final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
   }
   
 }
+
+extension RootNavigationCoordinator: UserSelectionHandling {
+  
+  func didSelect(user: GithubUser) {
+    dump(user)
+  }
+  
+}

--- a/iOS-Template/Coordinators/RootNavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/RootNavigationCoordinator.swift
@@ -31,7 +31,7 @@ final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
 extension RootNavigationCoordinator: UserSelectionHandling {
   
   func didSelect(user: GithubUser) {
-    controller.pushViewController(UIViewController(), animated: true)
+    controller.pushViewController(ReposListViewController(user: user), animated: true)
   }
   
 }

--- a/iOS-Template/Coordinators/RootNavigationCoordinator.swift
+++ b/iOS-Template/Coordinators/RootNavigationCoordinator.swift
@@ -19,9 +19,7 @@ final class RootNavigationCoordinator: NSObject, NavigationCoordinator {
   }
   
   private func makeRootViewController() -> UIViewController {
-    let viewController = UIViewController()
-    viewController.view.backgroundColor = .systemGreen
-    return viewController
+    return UsersListViewController()
   }
   
   func start() {

--- a/iOS-Template/Coordinators/RootWindowCoordinator.swift
+++ b/iOS-Template/Coordinators/RootWindowCoordinator.swift
@@ -1,0 +1,35 @@
+//
+//  RootWindowCoordinator.swift
+//  iOS-Template
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+class RootWindowCoordinator: NSObject, WindowCoordinator {
+  
+  private(set) var window: UIWindow
+  private(set) var childCoordinators: [Coordinator] = []
+  private let environment: Environment
+  
+  init(window: UIWindow, environment: Environment) {
+    self.window = window
+    self.environment = environment
+    super.init()
+  }
+  
+  convenience init?(scene: UIScene, environment: Environment) {
+    guard let windowScene = scene as? UIWindowScene else { return nil }
+    self.init(window: UIWindow(windowScene: windowScene), environment: environment)
+  }
+  
+  func start() {
+    let coordinator = RootNavigationCoordinator(environment: environment)
+    childCoordinators.append(coordinator)
+    window.rootViewController = coordinator.controller
+    window.makeKeyAndVisible()
+    coordinator.start()
+  }
+  
+}

--- a/iOS-Template/Coordinators/UserSelectionHandling.swift
+++ b/iOS-Template/Coordinators/UserSelectionHandling.swift
@@ -1,0 +1,14 @@
+//
+//  UserSelectionHandling.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import Foundation
+
+protocol UserSelectionHandling: NSObject {
+  
+  func didSelect(user: GithubUser)
+  
+}

--- a/iOS-Template/Coordinators/WindowCoordinator.swift
+++ b/iOS-Template/Coordinators/WindowCoordinator.swift
@@ -1,0 +1,16 @@
+//
+//  WindowCoordinator.swift
+//  iOS-Template
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+protocol WindowCoordinator: Coordinator {
+  
+  var window: UIWindow { get }
+  
+  var childCoordinators: [Coordinator] { get }
+  
+}

--- a/iOS-Template/Modules/Home/GithubModel.swift
+++ b/iOS-Template/Modules/Home/GithubModel.swift
@@ -25,3 +25,17 @@ struct GithubUser: Codable, Identifiable {
   let id: Int
   
 }
+
+extension Array where Element == GithubUser {
+  
+  static var placholderList: [GithubUser] {
+    [
+      GithubUser(login: "ASDF1", id: 1),
+      GithubUser(login: "ASDF2", id: 2),
+      GithubUser(login: "ASDF3", id: 3),
+      GithubUser(login: "ASDF4", id: 4),
+      GithubUser(login: "ASDF5", id: 5)
+    ]
+  }
+  
+}

--- a/iOS-Template/Modules/Home/GithubModel.swift
+++ b/iOS-Template/Modules/Home/GithubModel.swift
@@ -25,17 +25,3 @@ struct GithubUser: Codable, Identifiable {
   let id: Int
   
 }
-
-extension Array where Element == GithubUser {
-  
-  static var placholderList: [GithubUser] {
-    [
-      GithubUser(login: "ASDF1", id: 1),
-      GithubUser(login: "ASDF2", id: 2),
-      GithubUser(login: "ASDF3", id: 3),
-      GithubUser(login: "ASDF4", id: 4),
-      GithubUser(login: "ASDF5", id: 5)
-    ]
-  }
-  
-}

--- a/iOS-Template/Modules/Home/GithubModel.swift
+++ b/iOS-Template/Modules/Home/GithubModel.swift
@@ -19,6 +19,9 @@ struct GithubModel: Codable {
 }
 
 // MARK: - Item
-struct GithubUser: Codable {
+struct GithubUser: Codable, Identifiable {
+  
   let login: String
+  let id: Int
+  
 }

--- a/iOS-Template/Modules/RepoList/RepoModel.swift
+++ b/iOS-Template/Modules/RepoList/RepoModel.swift
@@ -6,6 +6,9 @@
 import Foundation
 
 // MARK: - Repository
-struct Repository: Codable {
+struct Repository: Codable, Identifiable {
+  
   let name: String
+  let id: Int
+  
 }

--- a/iOS-Template/Modules/ReposList/ReposListViewController.swift
+++ b/iOS-Template/Modules/ReposList/ReposListViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ReposListViewController.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import UIKit
+
+class ReposListViewController: UIViewController {
+  
+  private let user: GithubUser
+  
+  init(user: GithubUser) {
+    self.user = user
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemRed
+  }
+  
+}

--- a/iOS-Template/Modules/ReposList/ReposListViewController.swift
+++ b/iOS-Template/Modules/ReposList/ReposListViewController.swift
@@ -10,10 +10,19 @@ import UIKit
 
 final class ReposListViewController: UIViewController {
   
+  /// A GitHub user whose repositories must be shown.
   private let user: GithubUser
+  
+  /// A collection view that shows a list of the provided user's repositories.
   private let listView: UICollectionView
+  
+  /// A diffable data source that is responsible for configuring and populating the list view with repositories.
   private var repositoriesDataSource: RepositoriesDataSource!
+  
+  /// A set to hold cancellables from Combine pipelines.
   private var cancellables = Set<AnyCancellable>()
+  
+  /// A controller to handle networking.
   private let networkingController = NetworkingController()
   
   init(user: GithubUser) {

--- a/iOS-Template/Modules/ReposList/ReposListViewController.swift
+++ b/iOS-Template/Modules/ReposList/ReposListViewController.swift
@@ -7,18 +7,37 @@
 
 import UIKit
 
-class ReposListViewController: UIViewController {
+final class ReposListViewController: UIViewController {
   
   private let user: GithubUser
+  private let listView: UICollectionView
+  private var repositoriesDataSource: RepositoriesDataSource!
   
   init(user: GithubUser) {
     self.user = user
+    listView = UICollectionView(frame: .zero, collectionViewLayout: .insetGroupedListLayout)
     super.init(nibName: nil, bundle: nil)
+    let registration = UICollectionView.CellRegistration<UICollectionViewListCell, Repository> { (cell, _, repository) in
+      var configuration = cell.defaultContentConfiguration()
+      configuration.text = repository.name
+      cell.contentConfiguration = configuration
+    }
+    self.repositoriesDataSource = RepositoriesDataSource(
+      collectionView: listView,
+      cellProvider: { [weak self] (collectionView, indexPath, _) -> UICollectionViewCell? in
+        guard let repository = self?.repositoriesDataSource?[indexPath] else { return nil }
+        return collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: repository)
+      }
+    )
   }
   
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func loadView() {
+    self.view = listView
   }
   
   override func viewDidLoad() {

--- a/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
+++ b/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
@@ -1,0 +1,35 @@
+//
+//  RepositoriesDataSource.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import UIKit
+
+final class RepositoriesDataSource: UICollectionViewDiffableDataSource<Int, Int> {
+  
+  private var repositories: [Repository] = []
+  
+  subscript(indexPath: IndexPath) -> Repository {
+    repositories[indexPath.item]
+  }
+  
+  override init(
+    collectionView: UICollectionView,
+    cellProvider: @escaping UICollectionViewDiffableDataSource<Int, Int>.CellProvider
+  ) {
+    super.init(collectionView: collectionView, cellProvider: cellProvider)
+    replaceExistingRepositories(with: [])
+  }
+  
+  func replaceExistingRepositories(with newRepositories: [Repository]) {
+    let section = 0
+    var sectionSnapshot = snapshot(for: section)
+    sectionSnapshot.delete(repositories.map(\.id))
+    self.repositories = newRepositories
+    sectionSnapshot.append(repositories.map(\.id))
+    apply(sectionSnapshot, to: section)
+  }
+  
+}

--- a/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
+++ b/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class RepositoriesDataSource: UICollectionViewDiffableDataSource<Int, Int> {
   
-  private var repositories: [Repository] = []
+  private var repositories: [Repository]
   
   subscript(indexPath: IndexPath) -> Repository {
     repositories[indexPath.item]
@@ -19,6 +19,7 @@ final class RepositoriesDataSource: UICollectionViewDiffableDataSource<Int, Int>
     collectionView: UICollectionView,
     cellProvider: @escaping UICollectionViewDiffableDataSource<Int, Int>.CellProvider
   ) {
+    repositories = []
     super.init(collectionView: collectionView, cellProvider: cellProvider)
     replaceExistingRepositories(with: [])
   }

--- a/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
+++ b/iOS-Template/Modules/ReposList/RepositoriesDataSource.swift
@@ -24,6 +24,9 @@ final class RepositoriesDataSource: UICollectionViewDiffableDataSource<Int, Int>
     replaceExistingRepositories(with: [])
   }
   
+  /// Removes existing repositories in the data source's collection view and inserts the provided array with new
+  /// repositories.
+  /// - Parameter newUsers: An array of new repositories to replace in the collection view.
   func replaceExistingRepositories(with newRepositories: [Repository]) {
     let section = 0
     var sectionSnapshot = snapshot(for: section)

--- a/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
+++ b/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
   
-  private(set) var users: [GithubUser]
+  private var users: [GithubUser]
   
   subscript(id: GithubUser.ID) -> GithubUser? {
     users.first(where: { $0.id == id })

--- a/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
+++ b/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
@@ -1,0 +1,27 @@
+//
+//  GitHubUsersDataSource.swift
+//  iOS-Template
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
+  
+  private(set) var users: [GithubUser] = []
+  
+  subscript(id: GithubUser.ID) -> GithubUser? {
+    users.first(where: { $0.id == id })
+  }
+  
+  func replaceExistingUsers(with newUsers: [GithubUser]) {
+    let section = 0
+    var sectionSnapshot = snapshot(for: section)
+    sectionSnapshot.delete(users.map(\.id))
+    self.users = newUsers
+    sectionSnapshot.append(users.map(\.id))
+    apply(sectionSnapshot, to: section)
+  }
+  
+}

--- a/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
+++ b/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
   
+  /// An array of users to be shown in this data source's collection view.
   private var users: [GithubUser]
   
   subscript(id: GithubUser.ID) -> GithubUser? {
@@ -28,6 +29,8 @@ class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
     replaceExistingUsers(with: users)
   }
   
+  /// Removes existing users in the data source's collection view and inserts the provided array with new users.
+  /// - Parameter newUsers: An array of new users to replace in the collection view.
   func replaceExistingUsers(with newUsers: [GithubUser]) {
     let section = 0
     var sectionSnapshot = snapshot(for: section)

--- a/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
+++ b/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
@@ -15,6 +15,10 @@ class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
     users.first(where: { $0.id == id })
   }
   
+  subscript(indexPath: IndexPath) -> GithubUser {
+    users[indexPath.item]
+  }
+  
   override init(
     collectionView: UICollectionView,
     cellProvider: @escaping UICollectionViewDiffableDataSource<Int, Int>.CellProvider

--- a/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
+++ b/iOS-Template/Modules/UsersList/GitHubUsersDataSource.swift
@@ -9,10 +9,19 @@ import UIKit
 
 class GitHubUsersDataSource: UICollectionViewDiffableDataSource<Int, Int> {
   
-  private(set) var users: [GithubUser] = []
+  private(set) var users: [GithubUser]
   
   subscript(id: GithubUser.ID) -> GithubUser? {
     users.first(where: { $0.id == id })
+  }
+  
+  override init(
+    collectionView: UICollectionView,
+    cellProvider: @escaping UICollectionViewDiffableDataSource<Int, Int>.CellProvider
+  ) {
+    users = []
+    super.init(collectionView: collectionView, cellProvider: cellProvider)
+    replaceExistingUsers(with: users)
   }
   
   func replaceExistingUsers(with newUsers: [GithubUser]) {

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -8,7 +8,7 @@
 import Combine
 import UIKit
 
-final class UsersListViewController: UIViewController {
+final class UsersListViewController: UIViewController, UICollectionViewDelegate {
   
   private var listView: UICollectionView!
   private var usersDataSource: GitHubUsersDataSource!
@@ -18,6 +18,7 @@ final class UsersListViewController: UIViewController {
   init() {
     super.init(nibName: nil, bundle: nil)
     self.listView = UICollectionView(frame: .zero, collectionViewLayout: .insetGroupedListLayout)
+    listView.delegate = self
     let registration = UICollectionView.CellRegistration<UICollectionViewListCell, Int> { [weak self] (cell, _, userID) in
       guard let item = self?.usersDataSource?[userID] else { return }
       var configuration = cell.defaultContentConfiguration()
@@ -78,6 +79,10 @@ final class UsersListViewController: UIViewController {
     .asResult()
     .sink(receiveValue: callback)
     .store(in: &cancellables)
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    collectionView.deselectItem(at: indexPath, animated: true)
   }
   
 }

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class UsersListViewController: UIViewController, UICollectionViewDelegate {
   
-  private var listView: UICollectionView!
+  private var listView: UICollectionView
   private var usersDataSource: GitHubUsersDataSource!
   private var cancellables = Set<AnyCancellable>()
   private let networkingController = NetworkingController()
@@ -18,18 +18,18 @@ final class UsersListViewController: UIViewController, UICollectionViewDelegate 
   
   init(userSelectionHandler: UserSelectionHandling? = nil) {
     self.userSelectionHandler = userSelectionHandler
-    super.init(nibName: nil, bundle: nil)
     self.listView = UICollectionView(frame: .zero, collectionViewLayout: .insetGroupedListLayout)
+    super.init(nibName: nil, bundle: nil)
     listView.delegate = self
-    let registration = UICollectionView.CellRegistration<UICollectionViewListCell, Int> { [weak self] (cell, _, userID) in
+    let registration = UICollectionView.CellRegistration<UICollectionViewListCell, Int> { [weak self] cell, _, userID in
       guard let item = self?.usersDataSource?[userID] else { return }
       var configuration = cell.defaultContentConfiguration()
       configuration.text = item.login
       cell.contentConfiguration = configuration
     }
-    let diffableDataSource = GitHubUsersDataSource(collectionView: listView, cellProvider: { (collectionView, indexPath, userID) -> UICollectionViewCell? in
+    let diffableDataSource = GitHubUsersDataSource(collectionView: listView) { (collectionView, indexPath, userID) in
       collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: userID)
-    })
+    }
     self.usersDataSource = diffableDataSource
     let searchController = UISearchController(searchResultsController: nil)
     title = "GitHub User Search"

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -28,7 +28,6 @@ final class UsersListViewController: UIViewController {
       collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: userID)
     })
     self.usersDataSource = diffableDataSource
-    addPlaceholderData()
     let searchController = UISearchController(searchResultsController: nil)
     navigationItem.searchController = searchController
     observeSearchTextChanges(
@@ -49,17 +48,6 @@ final class UsersListViewController: UIViewController {
   
   override func loadView() {
     self.view = listView
-  }
-  
-  private func makeCollectionViewLayout() -> UICollectionViewLayout {
-    var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
-    listConfiguration.headerMode = .none
-    let layout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
-    return layout
-  }
-  
-  private func addPlaceholderData() {
-    usersDataSource.replaceExistingUsers(with: .placholderList)
   }
   
   private func observeSearchTextChanges(

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -14,8 +14,10 @@ final class UsersListViewController: UIViewController, UICollectionViewDelegate 
   private var usersDataSource: GitHubUsersDataSource!
   private var cancellables = Set<AnyCancellable>()
   private let networkingController = NetworkingController()
+  private weak var userSelectionHandler: UserSelectionHandling?
   
-  init() {
+  init(userSelectionHandler: UserSelectionHandling? = nil) {
+    self.userSelectionHandler = userSelectionHandler
     super.init(nibName: nil, bundle: nil)
     self.listView = UICollectionView(frame: .zero, collectionViewLayout: .insetGroupedListLayout)
     listView.delegate = self
@@ -83,6 +85,8 @@ final class UsersListViewController: UIViewController, UICollectionViewDelegate 
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     collectionView.deselectItem(at: indexPath, animated: true)
+    let user = usersDataSource[indexPath]
+    userSelectionHandler?.didSelect(user: user)
   }
   
 }

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -26,6 +26,8 @@ final class UsersListViewController: UIViewController {
     })
     self.usersDataSource = diffableDataSource
     addPlaceholderData()
+    let searchController = UISearchController(searchResultsController: nil)
+    navigationItem.searchController = searchController
   }
   
   @available(*, unavailable)

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -29,6 +29,9 @@ final class UsersListViewController: UIViewController {
     })
     self.usersDataSource = diffableDataSource
     let searchController = UISearchController(searchResultsController: nil)
+    title = "GitHub User Search"
+    searchController.definesPresentationContext = true
+    searchController.obscuresBackgroundDuringPresentation = false
     navigationItem.searchController = searchController
     observeSearchTextChanges(
       searchField: searchController.searchBar.searchTextField,

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -1,0 +1,62 @@
+//
+//  UsersListViewController.swift
+//  iOS-Template
+//
+//  Created by apple on 27/05/21.
+//
+
+import UIKit
+
+final class UsersListViewController: UIViewController {
+  
+  private var listView: UICollectionView!
+  private var usersDataSource: GitHubUsersDataSource!
+  
+  init() {
+    super.init(nibName: nil, bundle: nil)
+    self.listView = UICollectionView(frame: .zero, collectionViewLayout: .insetGroupedListLayout)
+    let registration = UICollectionView.CellRegistration<UICollectionViewListCell, Int> { [weak self] (cell, _, userID) in
+      guard let item = self?.usersDataSource?[userID] else { return }
+      var configuration = cell.defaultContentConfiguration()
+      configuration.text = item.login
+      cell.contentConfiguration = configuration
+    }
+    let diffableDataSource = GitHubUsersDataSource(collectionView: listView, cellProvider: { (collectionView, indexPath, userID) -> UICollectionViewCell? in
+      collectionView.dequeueConfiguredReusableCell(using: registration, for: indexPath, item: userID)
+    })
+    self.usersDataSource = diffableDataSource
+    addPlaceholderData()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func loadView() {
+    self.view = listView
+  }
+  
+  private func makeCollectionViewLayout() -> UICollectionViewLayout {
+    var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+    listConfiguration.headerMode = .none
+    let layout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
+    return layout
+  }
+  
+  private func addPlaceholderData() {
+    usersDataSource.replaceExistingUsers(with: .placholderList)
+  }
+  
+}
+
+extension UICollectionViewLayout {
+  
+  static var insetGroupedListLayout: UICollectionViewCompositionalLayout {
+    var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+    listConfiguration.headerMode = .none
+    let layout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
+    return layout
+  }
+  
+}

--- a/iOS-Template/Modules/UsersList/UsersListViewController.swift
+++ b/iOS-Template/Modules/UsersList/UsersListViewController.swift
@@ -10,10 +10,19 @@ import UIKit
 
 final class UsersListViewController: UIViewController, UICollectionViewDelegate {
   
+  /// A collection view that shows a list of users matching a search query.
   private var listView: UICollectionView
+  
+  /// A diffable data source that is responsible for configuring and populating the list view with users.
   private var usersDataSource: GitHubUsersDataSource!
+  
+  /// A set to hold cancellables from Combine pipelines.
   private var cancellables = Set<AnyCancellable>()
+  
+  /// A controller to handle networking.
   private let networkingController = NetworkingController()
+  
+  /// An object to handle user selection.
   private weak var userSelectionHandler: UserSelectionHandling?
   
   init(userSelectionHandler: UserSelectionHandling? = nil) {
@@ -56,6 +65,11 @@ final class UsersListViewController: UIViewController, UICollectionViewDelegate 
     self.view = listView
   }
   
+  /// Observes the search controller's text field for changes to its text, debounces for 200 ms, removes duplicates, and
+  /// fetches search results for the final text from the network.
+  /// - Parameters:
+  ///   - searchField: The text field to observe.
+  ///   - callback: A closure to execute when users are fetched from the network.
   private func observeSearchTextChanges(
     searchField: UISearchTextField,
     onSearchResults callback: @escaping (Result<[GithubUser], NetworkingError>) -> Void
@@ -93,6 +107,7 @@ final class UsersListViewController: UIViewController, UICollectionViewDelegate 
 
 extension UICollectionViewLayout {
   
+  /// A compositional layout with inset grouped appearance, with no section headers.
   static var insetGroupedListLayout: UICollectionViewCompositionalLayout {
     var listConfiguration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
     listConfiguration.headerMode = .none

--- a/iOS-Template/Networking/CombineExtensions.swift
+++ b/iOS-Template/Networking/CombineExtensions.swift
@@ -1,0 +1,49 @@
+//
+//  CombineExtensions.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import Combine
+import Foundation
+
+extension Publisher {
+  
+  /// Transforms values or errors from upstream into a `Result`.
+  /// - Returns: A publisher that publishes a Result with success if upstream sent a value or a failure
+  ///   if upstream sent an error and completes when upstream completes.
+  func asResult() -> AnyPublisher<Result<Output, Failure>, Never> {
+    self
+      .flatMap { Just(.success($0)) }
+      .catch { Just(.failure($0)) }
+      .eraseToAnyPublisher()
+  }
+  
+}
+
+extension AnyPublisher {
+  
+  /// Converts the provided value into a constant value publisher.
+  static func just(_ value: Output, failureType: Failure.Type = Failure.self) -> Self {
+    Just(value)
+      .setFailureType(to: Failure.self)
+      .eraseToAnyPublisher()
+  }
+  
+  /// Converts the provided error into a constant error publisher.
+  static func fail(outputType: Output.Type = Output.self, _ error: Failure) -> Self {
+    Fail(outputType: Output.self, failure: error)
+      .eraseToAnyPublisher()
+  }
+  
+}
+
+extension Error {
+  
+  /// Converts the receiver error into a constant error publisher.
+  func publisher<Output>(outputType: Output.Type = Output.self) -> AnyPublisher<Output, Self> {
+    return .fail(self)
+  }
+
+}

--- a/iOS-Template/Networking/NetworkingController.swift
+++ b/iOS-Template/Networking/NetworkingController.swift
@@ -35,4 +35,17 @@ struct NetworkingController {
       .eraseToAnyPublisher()
   }
   
+  func reposPublisher(for user: GithubUser) -> AnyPublisher<[Repository], NetworkingError> {
+    guard let url = urlProvider.makeReposURL(for: user) else {
+      return .fail(NetworkingError(urlErrorCode: .badURL))
+    }
+    return publisherProvider
+      .publisher(for: url)
+      .map(\.data)
+      .catch { AnyPublisher.fail(NetworkingError(urlError: $0)) }
+      .decode(type: [Repository].self, decoder: JSONDecoder())
+      .catch { _ in AnyPublisher.fail(NetworkingError.jsonDecodingError) }
+      .eraseToAnyPublisher()
+  }
+  
 }

--- a/iOS-Template/Networking/NetworkingController.swift
+++ b/iOS-Template/Networking/NetworkingController.swift
@@ -1,0 +1,38 @@
+//
+//  NetworkingController.swift
+//  Pods
+//
+//  Created by apple on 28/05/21.
+//
+
+import Combine
+import Foundation
+
+struct NetworkingController {
+  
+  private let publisherProvider: NetworkingPublisherProviding
+  private let urlProvider: URLProvider
+  
+  init(
+    publisherProvider: NetworkingPublisherProviding = URLSession.shared,
+    urlProvider: URLProvider = URLProvider()
+  ) {
+    self.publisherProvider = publisherProvider
+    self.urlProvider = urlProvider
+  }
+  
+  func usersPublisher(query: String, page: Int = 1) -> AnyPublisher<[GithubUser], NetworkingError> {
+    guard let url = urlProvider.makeSearchURL(query: query, page: page) else {
+      return .fail(NetworkingError(urlErrorCode: .badURL))
+    }
+    return publisherProvider
+      .publisher(for: url)
+      .map(\.data)
+      .catch { AnyPublisher.fail(NetworkingError(urlError: $0)) }
+      .decode(type: GithubModel.self, decoder: JSONDecoder())
+      .catch { _ in AnyPublisher.fail(NetworkingError.jsonDecodingError) }
+      .map(\.items)
+      .eraseToAnyPublisher()
+  }
+  
+}

--- a/iOS-Template/Networking/NetworkingController.swift
+++ b/iOS-Template/Networking/NetworkingController.swift
@@ -21,6 +21,11 @@ struct NetworkingController {
     self.urlProvider = urlProvider
   }
   
+  /// Returns a publisher that on success publishes an array of users matching the search result and the page number
+  /// provided, or fails with any networking error from upstream.
+  /// - Parameters:
+  ///   - query: The string to search for
+  ///   - page: The page number of search results. Defaults to 1.
   func usersPublisher(query: String, page: Int = 1) -> AnyPublisher<[GithubUser], NetworkingError> {
     guard let url = urlProvider.makeSearchURL(query: query, page: page) else {
       return .fail(NetworkingError(urlErrorCode: .badURL))
@@ -35,6 +40,11 @@ struct NetworkingController {
       .eraseToAnyPublisher()
   }
   
+  /// Returns a publisher that on success publishes an array of repositories belonging to the provided user, or fails
+  /// with any networking error from upstream.
+  /// - Parameters:
+  ///   - query: The string to search for
+  ///   - page: The page number of search results. Defaults to 1.
   func reposPublisher(for user: GithubUser) -> AnyPublisher<[Repository], NetworkingError> {
     guard let url = urlProvider.makeReposURL(for: user) else {
       return .fail(NetworkingError(urlErrorCode: .badURL))

--- a/iOS-Template/Networking/NetworkingError.swift
+++ b/iOS-Template/Networking/NetworkingError.swift
@@ -15,3 +15,15 @@ enum NetworkingError: Error {
   case jsonDecodingError
   case requestCancelled
 }
+
+extension NetworkingError {
+  
+  init(urlError error: URLError) {
+    self = .urlError(error)
+  }
+  
+  init(urlErrorCode code: URLError.Code) {
+    self.init(urlError: URLError(code))
+  }
+  
+}

--- a/iOS-Template/Networking/NetworkingPublisherProviding.swift
+++ b/iOS-Template/Networking/NetworkingPublisherProviding.swift
@@ -1,0 +1,31 @@
+//
+//  NetworkingPublisherProviding.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import Combine
+import Foundation
+
+protocol NetworkingPublisherProviding {
+  
+  func publisher(for url: URL) -> AnyPublisher<(data: Data, response: URLResponse), URLError>
+  
+  func publisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError>
+  
+}
+
+extension URLSession: NetworkingPublisherProviding {
+  
+  func publisher(for url: URL) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
+    dataTaskPublisher(for: url)
+      .eraseToAnyPublisher()
+  }
+  
+  func publisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
+    dataTaskPublisher(for: request)
+      .eraseToAnyPublisher()
+  }
+  
+}

--- a/iOS-Template/Networking/NetworkingPublisherProviding.swift
+++ b/iOS-Template/Networking/NetworkingPublisherProviding.swift
@@ -10,19 +10,27 @@ import Foundation
 
 protocol NetworkingPublisherProviding {
   
+  /// Provides a publisher that publishes data and a response successfully, or fails with a URL error for the given URL.
+  /// - Parameter url: The URL for which to create a publisher.
   func publisher(for url: URL) -> AnyPublisher<(data: Data, response: URLResponse), URLError>
   
+  /// Provides a publisher that publishes data and a response successfully, or fails with a URL error for the given URL request.
+  /// - Parameter url: The URL request for which to create a publisher.
   func publisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError>
   
 }
 
 extension URLSession: NetworkingPublisherProviding {
   
+  /// Returns a publisher that wraps a URL session data task publisher for a given URL.
+  /// - Parameter url: The URL for which to create a data task publisher.
   func publisher(for url: URL) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
     dataTaskPublisher(for: url)
       .eraseToAnyPublisher()
   }
   
+  /// Returns a publisher that wraps a URL session data task publisher for a given URL request.
+  /// - Parameter url: The URL request for which to create a data task publisher.
   func publisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
     dataTaskPublisher(for: request)
       .eraseToAnyPublisher()

--- a/iOS-Template/Networking/URLProvider.swift
+++ b/iOS-Template/Networking/URLProvider.swift
@@ -26,4 +26,10 @@ struct URLProvider {
     return components.url
   }
   
+  func makeReposURL(for user: GithubUser) -> URL? {
+    var components = self.components
+    components.path = "/users/\(user.login)/repos"
+    return components.url
+  }
+  
 }

--- a/iOS-Template/Networking/URLProvider.swift
+++ b/iOS-Template/Networking/URLProvider.swift
@@ -1,0 +1,29 @@
+//
+//  URLProvider.swift
+//  iOS-Template
+//
+//  Created by apple on 28/05/21.
+//
+
+import Foundation
+
+struct URLProvider {
+  
+  private let components: URLComponents = {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "api.github.com"
+    return components
+  }()
+  
+  func makeSearchURL(query: String, page: Int) -> URL? {
+    var components = self.components
+    components.path = "/search/users"
+    components.queryItems = [
+      URLQueryItem(name: "q", value: "\"\(query)\""),
+      URLQueryItem(name: "page", value: String(describing: page))
+    ]
+    return components.url
+  }
+  
+}

--- a/iOS-Template/Networking/URLProvider.swift
+++ b/iOS-Template/Networking/URLProvider.swift
@@ -16,6 +16,7 @@ struct URLProvider {
     return components
   }()
   
+  /// Makes a URL for searching GitHub for the search string provided and the page number of the expected results.
   func makeSearchURL(query: String, page: Int) -> URL? {
     var components = self.components
     components.path = "/search/users"
@@ -26,6 +27,7 @@ struct URLProvider {
     return components.url
   }
   
+  /// Makes a URL for fetching repositories belonging to the provided user.
   func makeReposURL(for user: GithubUser) -> URL? {
     var components = self.components
     components.path = "/users/\(user.login)/repos"

--- a/iOS-Template/Start/Environment.swift
+++ b/iOS-Template/Start/Environment.swift
@@ -11,7 +11,7 @@ struct Environment {
   
   var networking: Endpoints
   
-  fileprivate init(networking: Endpoints) {
+  init(networking: Endpoints) {
     self.networking = networking
   }
   

--- a/iOS-Template/Start/Environment.swift
+++ b/iOS-Template/Start/Environment.swift
@@ -8,9 +8,25 @@
 import Foundation
 
 struct Environment {
+  
   var networking: Endpoints
+  
+  fileprivate init(networking: Endpoints) {
+    self.networking = networking
+  }
+  
 }
 
 extension Environment {
-  static let live: Self = .init(networking: Networking())
+  
+  private static let live: Self = .init(networking: Networking())
+  
+  static var current: Self {
+    #if DEBUG
+    return .live
+    #else
+    return .live
+    #endif
+  }
+  
 }

--- a/iOS-Template/Start/SceneDelegate.swift
+++ b/iOS-Template/Start/SceneDelegate.swift
@@ -8,22 +8,15 @@
 import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-  
-  var window: UIWindow?
-  private var applicationCoordinator: ApplicationCoordinator?
-  private var environment: Environment = .current
+
+  private var windowCoordinator: RootWindowCoordinator!
 
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-    guard let windowScene = (scene as? UIWindowScene) else { return }
-    let window = UIWindow(frame: windowScene.coordinateSpace.bounds)
-    
-    let applicationCoordinator = ApplicationCoordinator(window: window, environment: environment)
-    window.windowScene = windowScene
-    self.window = window
-    self.applicationCoordinator = applicationCoordinator
-    
-    applicationCoordinator.start()
-
+    guard let coordinator = RootWindowCoordinator(scene: scene, environment: .current) else {
+      fatalError("Unexpected UIScene: \(scene)")
+    }
+    coordinator.start()
+    self.windowCoordinator = coordinator
   }
-  
+
 }

--- a/iOS-Template/Start/SceneDelegate.swift
+++ b/iOS-Template/Start/SceneDelegate.swift
@@ -11,17 +11,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   
   var window: UIWindow?
   private var applicationCoordinator: ApplicationCoordinator?
-  var environment: Environment!
+  private var environment: Environment = .current
 
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
     let window = UIWindow(frame: windowScene.coordinateSpace.bounds)
-    
-    #if DEBUG
-    environment = .live
-    #else
-    environment = .live
-    #endif
     
     let applicationCoordinator = ApplicationCoordinator(window: window, environment: environment)
     window.windowScene = windowScene

--- a/iOS-TemplateTests/Extensions/Extensions/NetworkingMock.swift
+++ b/iOS-TemplateTests/Extensions/Extensions/NetworkingMock.swift
@@ -17,9 +17,9 @@ struct NetworkingMock: Endpoints {
   mutating func getRepos(user: String, completion: @escaping (Result<[Repository], NetworkingError>) -> Void) {
     DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.0001) {
       let repos: [Repository] = [
-        Repository(name: "Repo1"),
-        Repository(name: "Repo2"),
-        Repository(name: "Repo3")
+        Repository(name: "Repo1", id: 1),
+        Repository(name: "Repo2", id: 2),
+        Repository(name: "Repo3", id: 3)
       ]
       completion(.success(repos))
     }
@@ -30,9 +30,9 @@ struct NetworkingMock: Endpoints {
         totalCount: 3,
         incompleteResults: false,
         items: [
-          GithubUser(login: "Viranchee"),
-          GithubUser(login: "virancheewednesday"),
-          GithubUser(login: "rameez")
+          GithubUser(login: "Viranchee", id: 1),
+          GithubUser(login: "virancheewednesday", id: 2),
+          GithubUser(login: "rameez", id: 3)
         ]
       )
       completion(.success(model))

--- a/iOS-TemplateTests/MockNetworkingPublisherProvider.swift
+++ b/iOS-TemplateTests/MockNetworkingPublisherProvider.swift
@@ -15,9 +15,7 @@ struct MockNetworkingPublisherProvider: NetworkingPublisherProviding {
   private let response: URLResponse
   
   private var publisher: AnyPublisher<(data: Data, response: URLResponse), URLError> {
-    Result.success((data, response))
-      .publisher
-      .eraseToAnyPublisher()
+    .just((data, response))
   }
   
   init(data: Data, response: HTTPURLResponse) {

--- a/iOS-TemplateTests/MockNetworkingPublisherProvider.swift
+++ b/iOS-TemplateTests/MockNetworkingPublisherProvider.swift
@@ -1,0 +1,36 @@
+//
+//  MockNetworkingPublisherProvider.swift
+//  iOS-TemplateTests
+//
+//  Created by apple on 01/06/21.
+//
+
+import Combine
+import Foundation
+@testable import iOS_Template
+
+struct MockNetworkingPublisherProvider: NetworkingPublisherProviding {
+  
+  private let data: Data
+  private let response: URLResponse
+  
+  private var publisher: AnyPublisher<(data: Data, response: URLResponse), URLError> {
+    Result.success((data, response))
+      .publisher
+      .eraseToAnyPublisher()
+  }
+  
+  init(data: Data, response: HTTPURLResponse) {
+    self.data = data
+    self.response = response
+  }
+  
+  func publisher(for url: URL) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
+    publisher
+  }
+  
+  func publisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), URLError> {
+    publisher
+  }
+  
+}

--- a/iOS-TemplateTests/NetworkingControllerTests.swift
+++ b/iOS-TemplateTests/NetworkingControllerTests.swift
@@ -1,0 +1,111 @@
+//
+//  NetworkingControllerTests.swift
+//  iOS-TemplateTests
+//
+//  Created by apple on 01/06/21.
+//
+
+import Combine
+import XCTest
+@testable import iOS_Template
+
+class NetworkingControllerTests: XCTestCase {
+  
+  private var cancellables: Set<AnyCancellable>!
+  
+  override func setUpWithError() throws {
+    cancellables = []
+  }
+  
+  override func tearDownWithError() throws {
+    cancellables = nil
+  }
+  
+  func testUsers() throws {
+    let data = try XCTUnwrap(usersJSON.data(using: .utf8))
+    let publisherProvider = MockNetworkingPublisherProvider(data: data, response: HTTPURLResponse())
+    let networkingController = NetworkingController(publisherProvider: publisherProvider)
+    
+    let query = "user"
+    let expectedCount = 3
+    let description = "Expect \(expectedCount) users with \"\(query)\" in their usernames."
+    let expectation = XCTestExpectation(description: description)
+    
+    networkingController
+      .usersPublisher(query: query)
+      .asResult()
+      .sink { result in
+        switch result {
+        case .success(let users):
+          XCTAssertEqual(users.count, expectedCount)
+          XCTAssertTrue(users.allSatisfy { $0.login.contains(query) })
+        case .failure(let error):
+          XCTFail(error.localizedDescription)
+        }
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
+    
+    wait(for: [expectation], timeout: 1.0)
+  }
+  
+  func testRepositories() throws {
+    let data = try XCTUnwrap(repositoriesJSON.data(using: .utf8))
+    let publisherProvider = MockNetworkingPublisherProvider(data: data, response: HTTPURLResponse())
+    let networkingController = NetworkingController(publisherProvider: publisherProvider)
+    
+    let username = "asdf"
+    let expectedCount = 2
+    let user = GithubUser(login: username, id: 1)
+    let description = "Expect \(expectedCount) repositories for user \"\(username)\""
+    let expectation = XCTestExpectation(description: description)
+    
+    networkingController
+      .reposPublisher(for: user)
+      .asResult()
+      .sink { result in
+        switch result {
+        case .success(let repositories): XCTAssertEqual(repositories.count, expectedCount)
+        case .failure(let error): XCTFail(error.localizedDescription)
+        }
+        expectation.fulfill()
+      }
+      .store(in: &cancellables)
+    wait(for: [expectation], timeout: 1.0)
+  }
+  
+}
+
+private let usersJSON = """
+{
+  "total_count": 3,
+  "incomplete_results": false,
+  "items": [
+    {
+      "login": "user123",
+      "id": 123
+    },
+    {
+      "login": "user456",
+      "id": 456
+    },
+    {
+      "login": "user789",
+      "id": 789
+    }
+  ]
+}
+"""
+
+private let repositoriesJSON = """
+[
+  {
+    "name": "repo1",
+    "id": 1
+  },
+  {
+    "name": "repo2",
+    "id": 2
+  }
+]
+"""

--- a/iOS-TemplateTests/URLProviderTests.swift
+++ b/iOS-TemplateTests/URLProviderTests.swift
@@ -1,0 +1,38 @@
+//
+//  URLProviderTests.swift
+//  iOS-TemplateTests
+//
+//  Created by apple on 01/06/21.
+//
+
+import XCTest
+@testable import iOS_Template
+
+class URLProviderTests: XCTestCase {
+  
+  private var urlProvider: URLProvider!
+  
+  override func setUpWithError() throws {
+    urlProvider = .init()
+  }
+  
+  override func tearDownWithError() throws {
+    urlProvider = nil
+  }
+  
+  func testUserURL() throws {
+    let query = "asdf"
+    let page = 1
+    let url = try XCTUnwrap(urlProvider.makeSearchURL(query: query, page: page))
+    let urlString = try XCTUnwrap(url.absoluteString)
+    XCTAssertEqual(urlString, "https://api.github.com/search/users?q=%22\(query)%22&page=\(page)")
+  }
+  
+  func testRepositoriesURL() throws {
+    let user = GithubUser(login: "asdf", id: 0)
+    let url = try XCTUnwrap(urlProvider.makeReposURL(for: user))
+    let urlString = try XCTUnwrap(url.absoluteString)
+    XCTAssertEqual(urlString, "https://api.github.com/users/\(user.login)/repos")
+  }
+  
+}


### PR DESCRIPTION
This PR adds an alternative app flow powered by Combine instead of RxSwift.

The new view controllers added in this feature show GH users and their repositories in a list view powered by the new iOS 14 collection view list configurations and diffable data sources.

At this point of time this alternative flow is realised in MVC-Coordinator architecture rather than MVVM-C. Transformation to MVVM-C is Work In Progress.

